### PR TITLE
fix(mcp): Python 3.10 compatibility and result formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from khive!")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary

Fixes khive MCP integration to work identically to Claude Code's native MCP client.

### Key Changes

- **Python 3.10 Compatibility**: Replace `asyncio.timeout` with `asyncio.wait_for` (asyncio.timeout was added in Python 3.11)
- **Result Formatting**: Extract JSON from MCP text responses to match Claude Code's clean output format
- **Timeout Improvements**: Increase default timeouts from 30s → 120s for better memory server stability
- **Cleanup**: Remove placeholder main.py file

### Before/After

**Before**: Raw MCP message format
```
type='text' text='{"content": "test", "type": "fact"}' annotations=None meta=None
```

**After**: Clean JSON like Claude Code
```json
{
  "content": "test", 
  "type": "fact",
  "relevance": 0.5,
  "id": "abc123"
}
```

### Testing

- ✅ All MCP tools now work (save, search, list_memories, search_by_type) 
- ✅ Connects to same memory database as Claude Code
- ✅ Compatible with Python 3.10.15

🤖 Generated with [Claude Code](https://claude.ai/code)